### PR TITLE
Use relative import on navbar for service

### DIFF
--- a/src/components/navbar/navbar.js
+++ b/src/components/navbar/navbar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 // eslint-disable-next-line
-import canUseDOM from 'services/can-use-dom';
+import canUseDOM from '../../services/can-use-dom';
 import Brand from './components/brand';
 import Burger from './components/burger';
 import Menu from './components/menu';


### PR DESCRIPTION
When importer navbar as a single component in another project that throw an error because services is not defined as a root resolver.

Solution: Use relative imports