### PR TITLE
remove unnecesary renderAs on Image Element in Media storybook

### DIFF
--- a/src/components/media/media.story.js
+++ b/src/components/media/media.story.js
@@ -20,7 +20,7 @@ storiesOf('Media', module)
       <Box>
         <Media>
           <Media.Item renderAs="figure" position="left">
-            <Image renderAs="p" size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
+            <Image size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
           </Media.Item>
           <Media.Item>
             <Content>


### PR DESCRIPTION
Fix #21 