### PR TITLE
Support for HTML5 number input

### DIFF
--- a/src/components/form/components/input.js
+++ b/src/components/form/components/input.js
@@ -10,7 +10,7 @@ export default class Input extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
     style: PropTypes.shape({}),
-    type: PropTypes.oneOf(['text', 'email', 'tel', 'password','number']),
+    type: PropTypes.oneOf(['text', 'email', 'tel', 'password', 'number']),
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     color: PropTypes.oneOf(colors),
     readOnly: PropTypes.bool,

--- a/src/components/form/components/input.js
+++ b/src/components/form/components/input.js
@@ -10,7 +10,7 @@ export default class Input extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
     style: PropTypes.shape({}),
-    type: PropTypes.oneOf(['text', 'email', 'tel', 'password']),
+    type: PropTypes.oneOf(['text', 'email', 'tel', 'password','number']),
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     color: PropTypes.oneOf(colors),
     readOnly: PropTypes.bool,


### PR DESCRIPTION
the number input should be supported as it queues mobile devices to present a number keyboard when its specified.
Bulma supports this type of input (which ends up being just a specialized text input)