### PR TITLE
add `time` as possible type for Input

### DIFF
--- a/src/components/form/components/input.js
+++ b/src/components/form/components/input.js
@@ -42,7 +42,7 @@ Input.propTypes = {
   ...modifiers.propTypes,
   className: PropTypes.string,
   style: PropTypes.shape({}),
-  type: PropTypes.oneOf(['text', 'email', 'tel', 'password', 'number', 'search', 'color', 'date']),
+  type: PropTypes.oneOf(['text', 'email', 'tel', 'password', 'number', 'search', 'color', 'date', 'time']),
   size: PropTypes.oneOf(['small', 'medium', 'large']),
   color: PropTypes.oneOf(colors),
   readOnly: PropTypes.bool,


### PR DESCRIPTION
I was trying to use the time input like described [here (on MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time) but it gave me errors.