### PR TITLE
Fix Checkbox component to propagate checked state

### DIFF
--- a/src/components/form/components/__test__/__snapshots__/checkbox.test.js.snap
+++ b/src/components/form/components/__test__/__snapshots__/checkbox.test.js.snap
@@ -9,6 +9,7 @@ exports[`Checkbox component Should have checkbox classname 1`] = `
   style={Object {}}
 >
   <input
+    checked={false}
     disabled={false}
     name={null}
     type="checkbox"

--- a/src/components/form/components/__test__/checkbox.test.js
+++ b/src/components/form/components/__test__/checkbox.test.js
@@ -23,4 +23,8 @@ describe('Checkbox component', () => {
     component.find('input').simulate('change');
     expect(spy).toHaveBeenCalledTimes(1);
   });
+  it('Should set input checked if checked', () => {
+    const component = shallow(<Checkbox checked />);
+    expect(component.find('input').is('[checked]')).toBe(true);
+  });
 });

--- a/src/components/form/components/checkbox.js
+++ b/src/components/form/components/checkbox.js
@@ -26,6 +26,7 @@ const Checkbox = ({
         type="checkbox"
         value={value}
         disabled={disabled}
+        checked={checked}
       />
       {children}
     </label>


### PR DESCRIPTION
Problem:

The Checkbox component lists `checked` as a `prop`, but it doesn't actually set the `checked` attribute of its `<input>`. 

Solution:

This PR propagates the checked state to the input.