### PR TITLE
Added support for 'is-up' in <Dropdown />, closes #107

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10774,12 +10774,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10794,17 +10796,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10921,7 +10926,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10933,6 +10939,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10947,6 +10954,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10954,12 +10962,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -10978,6 +10988,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11058,7 +11069,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11070,6 +11082,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11191,6 +11204,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
+++ b/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
@@ -63,7 +63,8 @@ exports[`Dropdown component Should appear above the dropdown button 1`] = `
 
 exports[`Dropdown component Should be right-aligned 1`] = `
 <div
-  className="dropdown is-right"
+  className="dropdown"
+  right={true}
   style={Object {}}
 >
   <div

--- a/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
+++ b/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
@@ -63,8 +63,7 @@ exports[`Dropdown component Should appear above the dropdown button 1`] = `
 
 exports[`Dropdown component Should be right-aligned 1`] = `
 <div
-  className="dropdown"
-  right={true}
+  className="dropdown is-right"
   style={Object {}}
 >
   <div

--- a/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
+++ b/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
@@ -61,7 +61,7 @@ exports[`Dropdown component Should appear above the dropdown button 1`] = `
 </div>
 `;
 
-exports[`Dropdown component Should be right-aligned 1`] = `
+exports[`Dropdown component Should be right-aligned when using "right" prop 1`] = `
 <div
   className="dropdown is-right"
   style={Object {}}
@@ -338,6 +338,65 @@ exports[`Dropdown component Should have dropdown classname 1`] = `
         title="value"
       >
         Item
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Dropdown component should also be right-aligned when using "align" prop 1`] = `
+<div
+  className="dropdown is-right"
+  style={Object {}}
+>
+  <div
+    className="dropdown-trigger"
+    onClick={[Function]}
+    role="presentation"
+  >
+    <button
+      className="button"
+      disabled={false}
+      onClick={[Function]}
+      style={Object {}}
+      tabIndex={0}
+    >
+      <span>
+        Item
+      </span>
+      <span
+        className="icon is-small"
+        style={Object {}}
+      >
+        <i
+          className="rbc rbc-angle-down"
+        />
+      </span>
+    </button>
+  </div>
+  <div
+    className="dropdown-menu"
+    id="dropdown-menu"
+    role="menu"
+  >
+    <div
+      className="dropdown-content"
+    >
+      <div
+        className="dropdown-item"
+        onClick={[Function]}
+        role="presentation"
+        title="value"
+      >
+        Item
+      </div>
+      <div
+        className="dropdown-item"
+        onClick={[Function]}
+        role="presentation"
+        title="other"
+      >
+        Other
       </div>
     </div>
   </div>

--- a/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
+++ b/src/components/dropdown/__test__/__snapshots__/dropdown.test.js.snap
@@ -2,6 +2,124 @@
 
 exports[`Dropdown component Should Exist 1`] = `[Function]`;
 
+exports[`Dropdown component Should appear above the dropdown button 1`] = `
+<div
+  className="dropdown is-up"
+  style={Object {}}
+>
+  <div
+    className="dropdown-trigger"
+    onClick={[Function]}
+    role="presentation"
+  >
+    <button
+      className="button"
+      disabled={false}
+      onClick={[Function]}
+      style={Object {}}
+      tabIndex={0}
+    >
+      <span>
+        Item
+      </span>
+      <span
+        className="icon is-small"
+        style={Object {}}
+      >
+        <i
+          className="rbc rbc-angle-down"
+        />
+      </span>
+    </button>
+  </div>
+  <div
+    className="dropdown-menu"
+    id="dropdown-menu"
+    role="menu"
+  >
+    <div
+      className="dropdown-content"
+    >
+      <div
+        className="dropdown-item"
+        onClick={[Function]}
+        role="presentation"
+        title="value"
+      >
+        Item
+      </div>
+      <div
+        className="dropdown-item"
+        onClick={[Function]}
+        role="presentation"
+        title="other"
+      >
+        Other
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Dropdown component Should be right-aligned 1`] = `
+<div
+  className="dropdown is-right"
+  style={Object {}}
+>
+  <div
+    className="dropdown-trigger"
+    onClick={[Function]}
+    role="presentation"
+  >
+    <button
+      className="button"
+      disabled={false}
+      onClick={[Function]}
+      style={Object {}}
+      tabIndex={0}
+    >
+      <span>
+        Item
+      </span>
+      <span
+        className="icon is-small"
+        style={Object {}}
+      >
+        <i
+          className="rbc rbc-angle-down"
+        />
+      </span>
+    </button>
+  </div>
+  <div
+    className="dropdown-menu"
+    id="dropdown-menu"
+    role="menu"
+  >
+    <div
+      className="dropdown-content"
+    >
+      <div
+        className="dropdown-item"
+        onClick={[Function]}
+        role="presentation"
+        title="value"
+      >
+        Item
+      </div>
+      <div
+        className="dropdown-item"
+        onClick={[Function]}
+        role="presentation"
+        title="other"
+      >
+        Other
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Dropdown component Should concat Bulma class with classes in props 1`] = `
 <div
   className="dropdown other-class"

--- a/src/components/dropdown/__test__/dropdown.test.js
+++ b/src/components/dropdown/__test__/dropdown.test.js
@@ -68,7 +68,7 @@ describe('Dropdown component', () => {
       </Dropdown>);
     expect(component.toJSON()).toMatchSnapshot();
   });
-  it('Should be right-aligned', () => {
+  it('Should be right-aligned when using "right" prop', () => {
     const component = renderer.create(
       <Dropdown right>
         <Dropdown.Item value="value">
@@ -79,6 +79,18 @@ describe('Dropdown component', () => {
         </Dropdown.Item>
       </Dropdown>);
     expect(component.toJSON()).toMatchSnapshot();
+  });
+  it('should also be right-aligned when using "align" prop', () => {
+    const component = renderer.create(
+      <Dropdown align="right">
+        <Dropdown.Item value="value">
+          Item
+        </Dropdown.Item>
+        <Dropdown.Item value="other">
+          Other
+        </Dropdown.Item>
+      </Dropdown>);
+      expect(component.toJSON()).toMatchSnapshot();
   });
   it('Should appear above the dropdown button', () => {
     const component = renderer.create(

--- a/src/components/dropdown/__test__/dropdown.test.js
+++ b/src/components/dropdown/__test__/dropdown.test.js
@@ -90,7 +90,7 @@ describe('Dropdown component', () => {
           Other
         </Dropdown.Item>
       </Dropdown>);
-      expect(component.toJSON()).toMatchSnapshot();
+    expect(component.toJSON()).toMatchSnapshot();
   });
   it('Should appear above the dropdown button', () => {
     const component = renderer.create(

--- a/src/components/dropdown/__test__/dropdown.test.js
+++ b/src/components/dropdown/__test__/dropdown.test.js
@@ -68,6 +68,30 @@ describe('Dropdown component', () => {
       </Dropdown>);
     expect(component.toJSON()).toMatchSnapshot();
   });
+  it('Should be right-aligned', () => {
+    const component = renderer.create(
+      <Dropdown right>
+        <Dropdown.Item value="value">
+          Item
+        </Dropdown.Item>
+        <Dropdown.Item value="other">
+          Other
+        </Dropdown.Item>
+      </Dropdown>);
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+  it('Should appear above the dropdown button', () => {
+    const component = renderer.create(
+      <Dropdown up>
+        <Dropdown.Item value="value">
+          Item
+        </Dropdown.Item>
+        <Dropdown.Item value="other">
+          Other
+        </Dropdown.Item>
+      </Dropdown>);
+    expect(component.toJSON()).toMatchSnapshot();
+  });
   it('Should open the Dropdown', () => {
     const component = shallow(
       <Dropdown value="value" style={{ width: 400 }} onChange={() => {}}>

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -24,7 +24,9 @@ export default class Dropdown extends PureComponent {
     value: PropTypes.any,
     onChange: PropTypes.func,
     color: PropTypes.oneOf(colors),
-    align: PropTypes.oneOf(['right']),
+    right: PropTypes.bool,
+    up: PropTypes.bool,
+    // align: PropTypes.oneOf(['right']),
     hoverable: PropTypes.bool,
   }
 
@@ -83,7 +85,9 @@ export default class Dropdown extends PureComponent {
       children,
       value,
       color,
-      align,
+      // align,
+      right,
+      up,
       hoverable,
       onChange,
       ...allProps
@@ -107,7 +111,9 @@ export default class Dropdown extends PureComponent {
         ref={(node) => { this.htmlElement = node; }}
         className={classnames('dropdown', modifiers.classnames(allProps), className, {
           'is-active': this.state.open,
-          [`is-${align}`]: align,
+          'is-right': right,
+          'is-up': up,
+          // [`is-${align}`]: align,
           'is-hoverable': hoverable,
         })}
       >

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -24,9 +24,8 @@ export default class Dropdown extends PureComponent {
     value: PropTypes.any,
     onChange: PropTypes.func,
     color: PropTypes.oneOf(colors),
-    right: PropTypes.bool,
     up: PropTypes.bool,
-    // align: PropTypes.oneOf(['right']),
+    align: PropTypes.oneOf(['right']),
     hoverable: PropTypes.bool,
   }
 
@@ -85,8 +84,7 @@ export default class Dropdown extends PureComponent {
       children,
       value,
       color,
-      // align,
-      right,
+      align,
       up,
       hoverable,
       onChange,
@@ -111,9 +109,8 @@ export default class Dropdown extends PureComponent {
         ref={(node) => { this.htmlElement = node; }}
         className={classnames('dropdown', modifiers.classnames(allProps), className, {
           'is-active': this.state.open,
-          'is-right': right,
           'is-up': up,
-          // [`is-${align}`]: align,
+          [`is-${align}`]: align,
           'is-hoverable': hoverable,
         })}
       >

--- a/src/components/dropdown/dropdown.js
+++ b/src/components/dropdown/dropdown.js
@@ -24,6 +24,7 @@ export default class Dropdown extends PureComponent {
     value: PropTypes.any,
     onChange: PropTypes.func,
     color: PropTypes.oneOf(colors),
+    right: PropTypes.bool,
     up: PropTypes.bool,
     align: PropTypes.oneOf(['right']),
     hoverable: PropTypes.bool,
@@ -85,6 +86,7 @@ export default class Dropdown extends PureComponent {
       value,
       color,
       align,
+      right,
       up,
       hoverable,
       onChange,
@@ -103,6 +105,11 @@ export default class Dropdown extends PureComponent {
       } : {});
     });
 
+    if (align === 'right') {
+      // eslint-disable-next-line no-console
+      console.warn('react-bulma-components: "Align" prop will be replaced by "right" prop in future releases. Please update your code to avoid breaking changes.');
+    }
+
     return (
       <div
         {...props}
@@ -110,7 +117,7 @@ export default class Dropdown extends PureComponent {
         className={classnames('dropdown', modifiers.classnames(allProps), className, {
           'is-active': this.state.open,
           'is-up': up,
-          [`is-${align}`]: align,
+          'is-right': right || align === 'right',
           'is-hoverable': hoverable,
         })}
       >

--- a/src/components/dropdown/dropdown.story.js
+++ b/src/components/dropdown/dropdown.story.js
@@ -89,7 +89,8 @@ storiesOf('Dropdown', module)
       <Container>
         <Section size="large">
           <Dropdown
-            align={select('align', alignment)}
+            align={select('align (deprecated; will be removed in future releases)', alignment)}
+            right={boolean('right (will replace "align" prop)', false)}
             up={boolean('up', false)}>
             <Dropdown.Item value="item" >
               Dropdown item

--- a/src/components/dropdown/dropdown.story.js
+++ b/src/components/dropdown/dropdown.story.js
@@ -1,11 +1,16 @@
 import React from 'react';
 
-import { boolean } from '@storybook/addon-knobs';
+import { boolean, select } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 import Dropdown from '.';
 import Container from '../container';
 import Section from '../section';
+
+const alignment = {
+  Default: '',
+  right: 'right'
+}
 
 class Wrapper extends React.Component {
   state = {
@@ -84,7 +89,7 @@ storiesOf('Dropdown', module)
       <Container>
         <Section size="large">
           <Dropdown
-            right={boolean('right', false)}
+            align={select('align', alignment)}
             up={boolean('up', false)}>
             <Dropdown.Item value="item" >
               Dropdown item

--- a/src/components/dropdown/dropdown.story.js
+++ b/src/components/dropdown/dropdown.story.js
@@ -1,8 +1,11 @@
 import React from 'react';
 
+import { boolean } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
 import Dropdown from '.';
+import Container from '../container';
+import Section from '../section';
 
 class Wrapper extends React.Component {
   state = {
@@ -76,5 +79,33 @@ storiesOf('Dropdown', module)
       </Dropdown.Item>
     </Dropdown>
   )))
+  .add('Alignment', () => (
+    <div>
+      <Container>
+        <Section size="large">
+          <Dropdown
+            right={boolean('right', false)}
+            up={boolean('up', false)}>
+            <Dropdown.Item value="item" >
+              Dropdown item
+            </Dropdown.Item>
+            <Dropdown.Item value="other">
+              Other Dropdown item
+            </Dropdown.Item>
+            <Dropdown.Item value="active">
+              Active Dropdown item
+            </Dropdown.Item>
+            <Dropdown.Item value="other 2">
+              Other Dropdown item
+            </Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item value="divider">
+              With divider
+            </Dropdown.Item>
+          </Dropdown>
+        </Section>
+      </Container>
+    </div>
+  ))
   .add('Controlled component', (() => <Wrapper />))
   .add('Controlled component Hoverable', (() => <Wrapper hoverable color="dark" />));


### PR DESCRIPTION
Doc for `is-up` modifier for `dropdown`: https://bulma.io/documentation/components/dropdown/#dropup  

`align` prop is replaced by `right` and `up` props because `is-right` and `is-up` modifiers can co-exist, but `align` only accepts `'right'` as the value; they are also more descriptive and are more aligned to the official documentation.  

Related issue: #107 