### PR TITLE
fixed examples with Image not to have unsupported renderAs prop

### DIFF
--- a/src/components/card/card.story.js
+++ b/src/components/card/card.story.js
@@ -20,7 +20,7 @@ storiesOf('Card', module)
       <Card.Content>
         <Media>
           <Media.Item renderAs="figure" position="left">
-            <Image renderAs="p" size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
+            <Image size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
           </Media.Item>
           <Media.Item>
             <Heading size={4}>John Smith</Heading>
@@ -45,7 +45,7 @@ storiesOf('Card', module)
       <Card.Content>
         <Media>
           <Media.Item renderAs="figure" position="left">
-            <Image renderAs="p" size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
+            <Image size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
           </Media.Item>
           <Media.Item>
             <Heading size={4}>John Smith</Heading>

--- a/src/components/media/media.story.js
+++ b/src/components/media/media.story.js
@@ -19,7 +19,7 @@ storiesOf('Media', module)
       <Box>
         <Media>
           <Media.Item renderAs="figure" position="left">
-            <Image renderAs="p" size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
+            <Image size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
           </Media.Item>
           <Media.Item>
             <Content>
@@ -59,7 +59,7 @@ storiesOf('Media', module)
       <Box>
         <Media renderAs="article">
           <Media.Item position="left">
-            <Image src="http://bulma.io/images/placeholders/128x128.png" size={64} renderAs="p" />
+            <Image src="http://bulma.io/images/placeholders/128x128.png" size={64} />
           </Media.Item>
           <Media.Item position="center">
             <Content>
@@ -74,7 +74,7 @@ storiesOf('Media', module)
 
             <Media>
               <Media.Item position="left">
-                <Image src="http://bulma.io/images/placeholders/128x128.png" size={48} renderAs="p" />
+                <Image src="http://bulma.io/images/placeholders/128x128.png" size={48} />
               </Media.Item>
               <Media.Item position="center">
                 <Content>
@@ -99,7 +99,7 @@ storiesOf('Media', module)
 
             <Media>
               <Media.Item position="left">
-                <Image src="http://bulma.io/images/placeholders/96x96.png" size={48} renderAs="p" />
+                <Image src="http://bulma.io/images/placeholders/96x96.png" size={48} />
               </Media.Item>
               <Media.Item position="center">
                 <Content>
@@ -117,7 +117,7 @@ storiesOf('Media', module)
         </Media>
         <Media renderAs="article">
           <Media.Item position="left">
-            <Image src="http://bulma.io/images/placeholders/128x128.png" size={64} renderAs="p" />
+            <Image src="http://bulma.io/images/placeholders/128x128.png" size={64} />
           </Media.Item>
           <Media.Item position="center">
             <Field>

--- a/src/components/modal/modal.story.js
+++ b/src/components/modal/modal.story.js
@@ -79,7 +79,7 @@ storiesOf('Modal', module)
         <Modal.Card.Body>
           <Media>
             <Media.Item renderAs="figure" position="left">
-              <Image renderAs="p" size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
+              <Image size={64} alt="64x64" src="http://bulma.io/images/placeholders/128x128.png" />
             </Media.Item>
             <Media.Item>
               <Content>


### PR DESCRIPTION
This fixes in particular 
https://github.com/couds/react-bulma-components/issues/144