### PR TITLE
extend input value PropType to accept numbers

### DIFF
--- a/src/components/form/components/input.js
+++ b/src/components/form/components/input.js
@@ -55,7 +55,10 @@ Input.propTypes = {
   isStatic: PropTypes.bool,
   disabled: PropTypes.bool,
   placeholder: PropTypes.string,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]),
   /**
    * The name of the input field Commonly used for [multi-input handling](https://reactjs.org/docs/forms.html#handling-multiple-inputs)
    */

--- a/src/components/form/components/input.js
+++ b/src/components/form/components/input.js
@@ -57,7 +57,7 @@ Input.propTypes = {
   placeholder: PropTypes.string,
   value: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.number
+    PropTypes.number,
   ]),
   /**
    * The name of the input field Commonly used for [multi-input handling](https://reactjs.org/docs/forms.html#handling-multiple-inputs)


### PR DESCRIPTION
The input value proptype is set to `string` so passing a number into to it, will show `Failed prop type: Invalid prop value of type number supplied to Input, expected string`. This commit extends the value prop to accept both numbers and strings. 

```js
<Input
    type="number"
    placeholder="Text input"
    value={1}
/>
```