### PR TITLE
Can now manually disable prev/next button in Pagination component

### DIFF
--- a/src/components/pagination/__test__/__snapshots__/pagination.test.js.snap
+++ b/src/components/pagination/__test__/__snapshots__/pagination.test.js.snap
@@ -1,6 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pagination component Next button should be disabled when current page equals the total number of pages 1`] = `
+exports[`Pagination component All buttons should be disabled 1`] = `
+<nav
+  aria-label="pagination"
+  className="pagination"
+>
+  <a
+    className="pagination-previous"
+    disabled={true}
+    role="button"
+    tabIndex={0}
+    title="This is the first page"
+  >
+    Previous
+  </a>
+  <a
+    className="pagination-next"
+    disabled={true}
+    role="button"
+    tabIndex={0}
+  >
+    Next
+  </a>
+  <ul
+    className="pagination-list"
+  >
+    <li>
+      <a
+        aria-current="page"
+        aria-label="Page 1"
+        className="pagination-link is-current"
+        disabled={true}
+        role="button"
+        tabIndex={0}
+      >
+        1
+      </a>
+    </li>
+    <li>
+      <a
+        aria-current="page"
+        aria-label="Page 2"
+        className="pagination-link"
+        disabled={true}
+        onClick={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        2
+      </a>
+    </li>
+    <li>
+      <a
+        aria-current="page"
+        aria-label="Page 3"
+        className="pagination-link"
+        disabled={true}
+        onClick={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        3
+      </a>
+    </li>
+  </ul>
+</nav>
+`;
+
+exports[`Pagination component Next button should be disabled 1`] = `
 <nav
   aria-label="pagination"
   className="pagination"
@@ -63,8 +130,6 @@ exports[`Pagination component Next button should be disabled when current page e
   </ul>
 </nav>
 `;
-
-exports[`Pagination component Next button should be disabled when the prop nextDisabled is given 1`] = `null`;
 
 exports[`Pagination component Pagination Should Exist 1`] = `[Function]`;
 

--- a/src/components/pagination/__test__/__snapshots__/pagination.test.js.snap
+++ b/src/components/pagination/__test__/__snapshots__/pagination.test.js.snap
@@ -1,13 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pagination component Next button should be disabled 1`] = `
+exports[`Pagination component Next button should be disabled when current page equals the total number of pages 1`] = `
 <nav
   aria-label="pagination"
   className="pagination"
 >
   <a
     className="pagination-previous"
-    disabled={false}
     onClick={[Function]}
     role="button"
     tabIndex={0}
@@ -65,6 +64,8 @@ exports[`Pagination component Next button should be disabled 1`] = `
 </nav>
 `;
 
+exports[`Pagination component Next button should be disabled when the prop nextDisabled is given 1`] = `null`;
+
 exports[`Pagination component Pagination Should Exist 1`] = `[Function]`;
 
 exports[`Pagination component Should have 3 pages and page 1 active 1`] = `
@@ -83,7 +84,6 @@ exports[`Pagination component Should have 3 pages and page 1 active 1`] = `
   </a>
   <a
     className="pagination-next"
-    disabled={false}
     onClick={[Function]}
     role="button"
     tabIndex={0}
@@ -139,7 +139,6 @@ exports[`Pagination component Should have 5 pages, page 5 active and display pag
 >
   <a
     className="pagination-previous"
-    disabled={false}
     onClick={[Function]}
     role="button"
     tabIndex={0}
@@ -275,7 +274,6 @@ exports[`Pagination component Should not display page numbers 1`] = `
 >
   <a
     className="pagination-previous"
-    disabled={false}
     onClick={[Function]}
     role="button"
     tabIndex={0}
@@ -297,3 +295,5 @@ exports[`Pagination component Should not display page numbers 1`] = `
 exports[`Pagination component Should not render if current page is greater than total pages 1`] = `null`;
 
 exports[`Pagination component Should not render if total pages equals 1 1`] = `null`;
+
+exports[`Pagination component previous button should be disabled when the prop prevDisabled is given 1`] = `null`;

--- a/src/components/pagination/__test__/__snapshots__/pagination.test.js.snap
+++ b/src/components/pagination/__test__/__snapshots__/pagination.test.js.snap
@@ -360,5 +360,3 @@ exports[`Pagination component Should not display page numbers 1`] = `
 exports[`Pagination component Should not render if current page is greater than total pages 1`] = `null`;
 
 exports[`Pagination component Should not render if total pages equals 1 1`] = `null`;
-
-exports[`Pagination component previous button should be disabled when the prop prevDisabled is given 1`] = `null`;

--- a/src/components/pagination/__test__/pagination.test.js
+++ b/src/components/pagination/__test__/pagination.test.js
@@ -31,10 +31,6 @@ describe('Pagination component', () => {
     const component = renderer.create(<Pagination total={3} current={1} disabled />);
     expect(component.toJSON()).toMatchSnapshot();
   });
-  it('previous button should be disabled when the prop prevDisabled is given', () => {
-    const component = renderer.create(<Pagination prevDisabled />);
-    expect(component.toJSON()).toMatchSnapshot();
-  });
   it('Should not render if total pages equals 1', () => {
     const component = renderer.create(<Pagination total={1} current={1} />);
     expect(component.toJSON()).toMatchSnapshot();

--- a/src/components/pagination/__test__/pagination.test.js
+++ b/src/components/pagination/__test__/pagination.test.js
@@ -23,16 +23,13 @@ describe('Pagination component', () => {
     const component = renderer.create(<Pagination showPrevNext={false} delta={3} total={5} current={2} />);
     expect(component.toJSON()).toMatchSnapshot();
   });
-  describe('Next button should be disabled', () => {
-    it('when current page equals the total number of pages', () => {
-      const component = renderer.create(<Pagination total={3} current={3} />);
-      expect(component.toJSON()).toMatchSnapshot();
-    });
-
-    it('when the prop nextDisabled is given', () => {
-      const component = renderer.create(<Pagination nextDisabled />);
-      expect(component.toJSON()).toMatchSnapshot();
-    });
+  it('Next button should be disabled', () => {
+    const component = renderer.create(<Pagination total={3} current={3} />);
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+  it('All buttons should be disabled', () => {
+    const component = renderer.create(<Pagination total={3} current={1} disabled />);
+    expect(component.toJSON()).toMatchSnapshot();
   });
   it('previous button should be disabled when the prop prevDisabled is given', () => {
     const component = renderer.create(<Pagination prevDisabled />);

--- a/src/components/pagination/__test__/pagination.test.js
+++ b/src/components/pagination/__test__/pagination.test.js
@@ -23,8 +23,19 @@ describe('Pagination component', () => {
     const component = renderer.create(<Pagination showPrevNext={false} delta={3} total={5} current={2} />);
     expect(component.toJSON()).toMatchSnapshot();
   });
-  it('Next button should be disabled', () => {
-    const component = renderer.create(<Pagination total={3} current={3} />);
+  describe('Next button should be disabled', () => {
+    it('when current page equals the total number of pages', () => {
+      const component = renderer.create(<Pagination total={3} current={3} />);
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+
+    it('when the prop nextDisabled is given', () => {
+      const component = renderer.create(<Pagination nextDisabled />);
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+  it('previous button should be disabled when the prop prevDisabled is given', () => {
+    const component = renderer.create(<Pagination prevDisabled />);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it('Should not render if total pages equals 1', () => {

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -9,6 +9,10 @@ export default class Pagination extends React.PureComponent {
     ...modifiers.propTypes,
     /** Current page */
     current: PropTypes.number,
+    /** Whether to disable "previous button" */
+    prevDisabled: PropTypes.bool,
+    /** Whether to disable "next button" */
+    nextDisabled: PropTypes.bool,
     /** Total pages in total */
     total: PropTypes.number,
     /** Amount og pages to display at the left and right of the current (if delta 2 and current page is 3, the paginator will display pages from 1 to 5) */
@@ -73,6 +77,8 @@ export default class Pagination extends React.PureComponent {
   render() {
     const {
       current,
+      prevDisabled,
+      nextDisabled,
       total,
       next,
       previous,
@@ -93,6 +99,8 @@ export default class Pagination extends React.PureComponent {
 
     const firstPage = this.firstPage(current, total);
     const lastPage = this.lastPage(current, total);
+    const disablePrev = current === 1 || prevDisabled;
+    const disableNext = current === total || nextDisabled;
 
     return (
       <Element
@@ -107,19 +115,19 @@ export default class Pagination extends React.PureComponent {
               <a
                 role="button"
                 tabIndex={0}
-                onClick={current === 1 ? undefined : this.goToPage(current - 1)}
+                onClick={disablePrev ? undefined : this.goToPage(current - 1)}
                 className="pagination-previous"
                 title="This is the first page"
-                disabled={current === 1}
+                disabled={disablePrev}
               >
                 {previous}
               </a>
               <a
                 role="button"
                 tabIndex={0}
-                onClick={current === total ? undefined : this.goToPage(current + 1)}
+                onClick={disableNext? undefined : this.goToPage(current + 1)}
                 className="pagination-next"
-                disabled={current === total}
+                disabled={disableNext || nextDisabled}
               >
                 {next}
               </a>

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -127,7 +127,7 @@ export default class Pagination extends React.PureComponent {
               <a
                 role="button"
                 tabIndex={0}
-                onClick={disableNext? undefined : this.goToPage(current + 1)}
+                onClick={disableNext ? undefined : this.goToPage(current + 1)}
                 className="pagination-next"
                 disabled={disableNext || nextDisabled}
               >

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -9,10 +9,8 @@ export default class Pagination extends React.PureComponent {
     ...modifiers.propTypes,
     /** Current page */
     current: PropTypes.number,
-    /** Whether to disable "previous button" */
-    prevDisabled: PropTypes.bool,
-    /** Whether to disable "next button" */
-    nextDisabled: PropTypes.bool,
+    /** whether to disable the buttons */
+    disabled: PropTypes.bool,
     /** Total pages in total */
     total: PropTypes.number,
     /** Amount og pages to display at the left and right of the current (if delta 2 and current page is 3, the paginator will display pages from 1 to 5) */
@@ -39,8 +37,7 @@ export default class Pagination extends React.PureComponent {
     next: 'Next',
     previous: 'Previous',
     showPrevNext: true,
-    prevDisabled: undefined,
-    nextDisabled: undefined,
+    disabled: undefined,
     autoHide: true,
     className: undefined,
     renderAs: 'nav',
@@ -79,8 +76,7 @@ export default class Pagination extends React.PureComponent {
   render() {
     const {
       current,
-      prevDisabled,
-      nextDisabled,
+      disabled,
       total,
       next,
       previous,
@@ -101,8 +97,8 @@ export default class Pagination extends React.PureComponent {
 
     const firstPage = this.firstPage(current, total);
     const lastPage = this.lastPage(current, total);
-    const disablePrev = current === 1 || prevDisabled;
-    const disableNext = current === total || nextDisabled;
+    const prevDisabled = current === 1 || disabled;
+    const nextDisabled = current === total || disabled;
 
     return (
       <Element
@@ -117,19 +113,19 @@ export default class Pagination extends React.PureComponent {
               <a
                 role="button"
                 tabIndex={0}
-                onClick={disablePrev ? undefined : this.goToPage(current - 1)}
+                onClick={prevDisabled ? undefined : this.goToPage(current - 1)}
                 className="pagination-previous"
                 title="This is the first page"
-                disabled={disablePrev}
+                disabled={prevDisabled}
               >
                 {previous}
               </a>
               <a
                 role="button"
                 tabIndex={0}
-                onClick={disableNext ? undefined : this.goToPage(current + 1)}
+                onClick={nextDisabled ? undefined : this.goToPage(current + 1)}
                 className="pagination-next"
-                disabled={disableNext || nextDisabled}
+                disabled={nextDisabled}
               >
                 {next}
               </a>
@@ -154,6 +150,7 @@ export default class Pagination extends React.PureComponent {
                         onClick={current === firstPage + i ? undefined : this.goToPage(firstPage + i)}
                         aria-label={`Page ${i + firstPage}`}
                         aria-current="page"
+                        disabled={disabled}
                       >
                         {i + firstPage}
                       </a>

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -39,6 +39,8 @@ export default class Pagination extends React.PureComponent {
     next: 'Next',
     previous: 'Previous',
     showPrevNext: true,
+    prevDisabled: undefined,
+    nextDisabled: undefined,
     autoHide: true,
     className: undefined,
     renderAs: 'nav',

--- a/src/components/pagination/pagination.story.js
+++ b/src/components/pagination/pagination.story.js
@@ -16,4 +16,7 @@ storiesOf('Pagination', module)
   )))
   .add('Without prev/next button', (() => (
     <Pagination showPrevNext={false} current={3} total={5} delta={1} />
+  )))
+  .add('With prev/next button manually disabled', (() => (
+      <Pagination prevDisabled nextDisabled current={3} total={5} />
   )));

--- a/src/components/pagination/pagination.story.js
+++ b/src/components/pagination/pagination.story.js
@@ -17,6 +17,6 @@ storiesOf('Pagination', module)
   .add('Without prev/next button', (() => (
     <Pagination showPrevNext={false} current={3} total={5} delta={1} />
   )))
-  .add('With prev/next button manually disabled', (() => (
-      <Pagination prevDisabled nextDisabled current={3} total={5} />
+  .add('With all buttons manually disabled', (() => (
+      <Pagination disabled current={3} total={5} />
   )));


### PR DESCRIPTION
A prop `disabled: PropTypes.bool` is added to `<Pagination />` which disables all buttons in pagination.
Closes #150.