### PR TITLE
List items containing custom children will now be styled correctly

### DIFF
--- a/src/components/menu/__test__/__snapshots__/menu.test.js.snap
+++ b/src/components/menu/__test__/__snapshots__/menu.test.js.snap
@@ -120,13 +120,17 @@ exports[`Menu component Should render custom item child 1`] = `
     className="menu-list"
   >
     <li>
-      <p>
-        Custom children 1
-      </p>
+      <a>
+        <p>
+          Custom children 1
+        </p>
+      </a>
     </li>
     <li>
       <a>
-        Custom children 2
+        <a>
+          Custom children 2
+        </a>
       </a>
     </li>
   </ul>

--- a/src/components/menu/__test__/__snapshots__/menu.test.js.snap
+++ b/src/components/menu/__test__/__snapshots__/menu.test.js.snap
@@ -48,34 +48,36 @@ exports[`Menu component Should concat Menu.List to display as submenus 1`] = `
       </a>
     </li>
     <li>
-      <li>
-        <a
-          className="is-active"
-        >
-          Manage Your Team
-        </a>
-        <ul
-          className="menu-list"
-        >
-          <li>
-            <a>
-              Members
-            </a>
-          </li>
-          <li>
-            <a
-              className="is-active"
-            >
-              Plugins
-            </a>
-          </li>
-          <li>
-            <a>
-              Add a member
-            </a>
-          </li>
-        </ul>
-      </li>
+      <a>
+        <li>
+          <a
+            className="is-active"
+          >
+            Manage Your Team
+          </a>
+          <ul
+            className="menu-list"
+          >
+            <li>
+              <a>
+                Members
+              </a>
+            </li>
+            <li>
+              <a
+                className="is-active"
+              >
+                Plugins
+              </a>
+            </li>
+            <li>
+              <a>
+                Add a member
+              </a>
+            </li>
+          </ul>
+        </li>
+      </a>
     </li>
   </ul>
 </aside>

--- a/src/components/menu/components/list/components/item.js
+++ b/src/components/menu/components/list/components/item.js
@@ -13,17 +13,7 @@ const MenuListItem = ({
   domRef: ref,
   ...props
 }) => {
-  if (typeof children === 'string' || typeof React.Children.only(children).type === 'string') {
-    return (
-      <li ref={ref}>
-        <Element className={classnames(className, { 'is-active': active })} {...props}>
-          {children}
-        </Element>
-      </li>
-    );
-  }
-
-  if (React.Children.only(children).type === List) {
+  if (typeof children !== 'string' && React.Children.toArray(children).length === 1 && React.Children.only(children).type === List) {
     const child = React.Children.only(children);
     return (
       <li ref={ref}>
@@ -37,7 +27,9 @@ const MenuListItem = ({
 
   return (
     <li ref={ref}>
-      {children}
+      <Element className={classnames(className, { 'is-active': active })} {...props}>
+        {children}
+      </Element>
     </li>
   );
 };

--- a/src/components/menu/components/list/components/item.js
+++ b/src/components/menu/components/list/components/item.js
@@ -13,7 +13,7 @@ const MenuListItem = ({
   domRef: ref,
   ...props
 }) => {
-  if (typeof children === 'string') {
+  if (typeof children === 'string' || typeof React.Children.only(children).type === 'string') {
     return (
       <li ref={ref}>
         <Element className={classnames(className, { 'is-active': active })} {...props}>

--- a/src/components/menu/menu.story.js
+++ b/src/components/menu/menu.story.js
@@ -34,7 +34,9 @@ storiesOf('Menu', module)
           </Menu.List>
         </Menu.List.Item>
         <Menu.List.Item>
-          Invitations
+          <div>
+            test
+          </div>
         </Menu.List.Item>
         <Menu.List.Item>
           Cloud Storage Environment Settings

--- a/src/components/menu/menu.story.js
+++ b/src/components/menu/menu.story.js
@@ -34,9 +34,7 @@ storiesOf('Menu', module)
           </Menu.List>
         </Menu.List.Item>
         <Menu.List.Item>
-          <div>
-            test
-          </div>
+          Invitations
         </Menu.List.Item>
         <Menu.List.Item>
           Cloud Storage Environment Settings


### PR DESCRIPTION
Content inside `list-item` must be wrapped with an `<a>` anchor or the list item will not be styled correctly.  

Closes #169 