### PR TITLE
Add Grey color to possible colors

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ export default {
     WARNING: 'warning',
     DANGER: 'danger',
     LIGHT: 'light',
+    GREY: 'grey',
     DARK: 'dark',
     WHITE: 'white',
     BLACK: 'black',


### PR DESCRIPTION
Among [Bulma initial values](https://github.com/jgthms/bulma/blob/master/sass/utilities/initial-variables.sass), [`$grey`](https://github.com/jgthms/bulma/blob/5713a124a25800a19c2d212e7d884332470b8a65/sass/utilities/initial-variables.sass#L9) is not present.
We will gain having it in the possible colour values as it is neither close to already supported `$light` nor `$dark`.
For instance, disabled entries should have a `grey` `Icon` colour.