### PR TITLE
Fixed react and react-dom peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   },
   "peerDependencies": {
     "prop-types": ">=15.6.0",
-    "react": "16.3.0",
-    "react-dom": "16.3.0"
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
   },
   "devDependencies": {
     "@babel/cli": "7.2.3",


### PR DESCRIPTION
Peer dependencies for react and react-dom were fixed to version 16.3.0. Made that into a minimal requirement.

Fixes #191