### PR TITLE
Change order of imports in utils.scss

### DIFF
--- a/src/components/utils.sass
+++ b/src/components/utils.sass
@@ -1,7 +1,7 @@
 @charset "utf-8"
 
-@import '~bulma/sass/utilities/initial-variables.sass'
 @import "_variables.sass"
+@import '~bulma/sass/utilities/initial-variables.sass'
 @import "~bulma/sass/utilities/functions.sass"
 @import "~bulma/sass/utilities/derived-variables.sass"
 @import "~bulma/sass/utilities/animations.sass"


### PR DESCRIPTION

The SASS `!default` syntax expects the "override" to be defined before the fallback. Thus `_variables.scss` should come first.

The new ordering will allow to, for example, define a different value for `$gap`, which will be taken into account in `~bulma/sass/utilities/initial-variables.sass` in calculating value for `$desktop`.

In the current ordering if i want to change the value for `$gap` i have to also modify values for all other variables where value of `$gap` is used.