### PR TITLE
fix: remove method on html element this.portalElement

### DIFF
--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -39,7 +39,11 @@ class Modal extends PureComponent {
     if (closeOnEsc && doc) {
       doc.removeEventListener('keydown', this.handleKeydown);
     }
-    this.portalElement.remove();
+    // check if the portalElement is a thing
+    if (this.portalElement) {
+      // find its parent and tell the parent to remove the portalElement
+      this.portalElement.parentNode.removeChild(this.portalElement);
+    }
   }
 
   getDocument = () => {

--- a/src/components/modal/modal.js
+++ b/src/components/modal/modal.js
@@ -39,11 +39,8 @@ class Modal extends PureComponent {
     if (closeOnEsc && doc) {
       doc.removeEventListener('keydown', this.handleKeydown);
     }
-    // check if the portalElement is a thing
-    if (this.portalElement) {
-      // find its parent and tell the parent to remove the portalElement
-      this.portalElement.parentNode.removeChild(this.portalElement);
-    }
+    // IE11 fix
+    this.portalElement.parentNode.removeChild(this.portalElement);
   }
 
   getDocument = () => {


### PR DESCRIPTION
IE11 does not support the remove method on HTML elements. This PR implements a recommended way around it.