### PR TITLE
Fix/input file

### DIFF
--- a/src/components/form/__test__/__snapshots__/file-input.test.js.snap
+++ b/src/components/form/__test__/__snapshots__/file-input.test.js.snap
@@ -13,7 +13,6 @@ exports[`Dropdown component Should render file input tree 1`] = `
       className="file-input"
       onChange={[Function]}
       type="file"
-      value=""
     />
     <span
       className="file-cta"
@@ -42,7 +41,6 @@ exports[`Dropdown component should pass file attributes 1`] = `
       multiple={true}
       onChange={[Function]}
       type="file"
-      value=""
     />
     <span
       className="file-cta"

--- a/src/components/form/components/input-file.js
+++ b/src/components/form/components/input-file.js
@@ -63,7 +63,6 @@ export default class InputFile extends PureComponent {
           <input
             {...inputProps}
             name={name}
-            value=""
             type="file"
             className="file-input"
             onChange={this.select}


### PR DESCRIPTION
I am using InputFile, but it seems that having a value="" prop on the &lt;input type="file"/&gt; component prevents accessing or posting the selected file's contents.

See this demo using v3.1.3: https://glitch.com/~ambitious-soursop

I removed that line from src/components/form/components/input-file.js and its test snapshot, and that seems to have fixed the problem. 

See demo with this change: https://glitch.com/~canyon-hotel