### PR TITLE
Make pagination to be fixed-length

### DIFF
--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -11,14 +11,15 @@ export default class Pagination extends React.PureComponent {
     onChange(page);
   }
 
-  firstPage = (current, total) => {
+  firstPage = (current, last) => {
     const { delta } = this.props;
 
     if (current === 1) {
       return 1;
     }
 
-    const page = current - (delta * (current === total ? 2 : 1));
+    const minPage = last - (delta * 2);
+    const page = current - delta < minPage ? current - delta : minPage;
 
     return page <= 0 ? 1 : page;
   }
@@ -30,7 +31,8 @@ export default class Pagination extends React.PureComponent {
       return total;
     }
 
-    const page = current + (delta * (current === 1 ? 2 : 1));
+    const maxPage =  delta * 2 + 1;
+    const page = current + delta > maxPage ? current + delta : maxPage;
 
     return page > total ? total : page;
   }
@@ -57,8 +59,8 @@ export default class Pagination extends React.PureComponent {
       return null;
     }
 
-    const firstPage = this.firstPage(current, total);
     const lastPage = this.lastPage(current, total);
+    const firstPage = this.firstPage(current, lastPage);
     const prevDisabled = current === 1 || disabled;
     const nextDisabled = current === total || disabled;
 

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -19,7 +19,7 @@ export default class Pagination extends React.PureComponent {
     }
 
     const minPage = last - (delta * 2);
-    const page = current - delta < minPage ? current - delta : minPage;
+    const page = Math.min(current - delta, minPage);
 
     return page <= 0 ? 1 : page;
   }
@@ -32,7 +32,7 @@ export default class Pagination extends React.PureComponent {
     }
 
     const maxPage =  delta * 2 + 1;
-    const page = current + delta > maxPage ? current + delta : maxPage;
+    const page = Math.max(current + delta, maxPage);
 
     return page > total ? total : page;
   }


### PR DESCRIPTION
Currently, the code `<Pagination current={current} total={5} delta={2} />` produces varied-size paginations depending on the `current` page, e.g.
* `current=1` => [1, 2, 3, 4, 5]
* `current=2` => [1, 2, 3, 4]
* `current=3` => [1, 2, 3, 4, 5]
* `current=4` => [2, 3, 4, 5]
* `current=5` => [1, 2, 3, 4, 5]

I would expect the pagination to stay the same size ([1, 2, 3, 4, 5], i.e. `min(total, 2 * delta + 1)`) regardless of `current` changes, so this PR does that. 
Btw, I wasn't sure if the library is allowed to use Math.max and Math.min, so the PR uses simple comparison instead!

Full CRA code to reproduce the behaviour:
```
import React, { useState } from 'react';
import Pagination from './react-bulma-components/src/components/pagination';
import './App.scss';

function App() {
  const [current, setCurrent] = useState(1);
  return (
    <div className="App">
      <Pagination current={current} total={5} delta={2} onChange={(page) => setCurrent(page)} />
    </div>
  );
}

export default App;
```
