### PR TITLE
fix: Progress value should be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1304,7 +1304,7 @@ interface ProgressModifierProps {
   size?: "small" | "medium" | "large";
   // todo: https://github.com/couds/react-bulma-components/issues/112
   max: number;
-  value: number;
+  value?: number;
 }
 interface ProgressProps
   extends ModifierProps,


### PR DESCRIPTION
In trying to add a Progress component to my app, I realized the typing currently does not allow for [Indeterminate Progress Bars](https://bulma.io/documentation/elements/progress/#indeterminate) as they can only be triggered when `value` is not added, and it's not an optional property.

This fixes that to conform with docs and allow indeterminate loaders.
