### PR TITLE
fix: add missing table hoverable prop

### DIFF
--- a/src/components/table/table.js
+++ b/src/components/table/table.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import modifiers from '../../modifiers';
 import Element from '../element';
 
-const Table = ({ children, className, size, striped, bordered, ...props }) => (
+const Table = ({ children, className, size, striped, bordered, hoverable, ...props }) => (
   <Element
     renderAs="table"
     {...props}
@@ -12,6 +12,7 @@ const Table = ({ children, className, size, striped, bordered, ...props }) => (
       [`is-${size}`]: size,
       'is-bordered': bordered,
       'is-striped': striped,
+      'is-hoverable': hoverable,
     })}
   >
     {children}
@@ -26,6 +27,7 @@ Table.propTypes = {
   size: PropTypes.oneOf(['fullwidth', 'narrow']),
   striped: PropTypes.bool,
   bordered: PropTypes.bool,
+  hoverable: PropTypes.bool,
 };
 
 Table.defaultProps = {
@@ -36,6 +38,7 @@ Table.defaultProps = {
   size: 'fullwidth',
   striped: true,
   bordered: false,
+  hoverable: false,
 };
 
 export default Table;


### PR DESCRIPTION
This PR fixes a missing Table modifier for hoverability:

<img width="790" alt="Screen Shot 2020-08-01 at 8 15 27 AM" src="https://user-images.githubusercontent.com/2036040/89104580-2c1cd700-d3cf-11ea-9efc-6b405a6ed593.png">

I wasn't sure whether to also add a new storybook example (there don't seem to be many for Table modifiers) but can if needed!

cc @MrCreeper1008