### PR TITLE
Add string column widths to types

### DIFF
--- a/src/components/columns/index.d.ts
+++ b/src/components/columns/index.d.ts
@@ -12,7 +12,29 @@ interface ColumnGroupProps {
   vCentered?: boolean;
 }
 
-type ColumnSize = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+type ColumnSize =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12
+  | 'three-quarters'
+  | 'two-thirds'
+  | 'half'
+  | 'one-third'
+  | 'one-quarter'
+  | 'one-fifth'
+  | 'two-fifths'
+  | 'three-fifths'
+  | 'four-fifths';
 
 interface ColumnBreakpointConfiguration {
   size?: ColumnSize;


### PR DESCRIPTION
Adds string-style column widths to types to avoid type errors on legitimate widths.