### PR TITLE
Make value and max props optional in Progress component

### DIFF
--- a/src/components/progress/index.d.ts
+++ b/src/components/progress/index.d.ts
@@ -2,8 +2,8 @@ import { BulmaComponentWithoutRenderAs } from '..';
 import { Size } from '..'
 
 interface ProgressProps {
-  value: number;
-  max: number;
+  value?: number;
+  max?: number;
   size?: Size;
 }
 


### PR DESCRIPTION
Allows creating Indeterminate [progress bars](https://bulma.io/documentation/elements/progress/#indeterminate).
