### PR TITLE
add only icon-text class when Icon text prop is enabled

### DIFF
--- a/src/components/icon/__test__/__snapshots__/icon.test.js.snap
+++ b/src/components/icon/__test__/__snapshots__/icon.test.js.snap
@@ -4,7 +4,7 @@ exports[`Icon component Should Exist 1`] = `[Function]`;
 
 exports[`Icon component Should concat Bulma class with classes in props 1`] = `
 <span
-  className="icon other-class"
+  className="other-class icon"
   icon="bars"
 />
 `;
@@ -12,6 +12,13 @@ exports[`Icon component Should concat Bulma class with classes in props 1`] = `
 exports[`Icon component Should have box classname 1`] = `
 <span
   className="icon"
+  icon="bars"
+/>
+`;
+
+exports[`Icon component Should only enable icon-text class if text prop is enabled 1`] = `
+<span
+  className="icon-text"
   icon="bars"
 />
 `;

--- a/src/components/icon/__test__/icon.test.js
+++ b/src/components/icon/__test__/icon.test.js
@@ -16,4 +16,8 @@ describe('Icon component', () => {
     );
     expect(component.toJSON()).toMatchSnapshot();
   });
+  it('Should only enable icon-text class if text prop is enabled', () => {
+    const component = renderer.create(<Icon text icon="bars" />);
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -8,7 +8,8 @@ const Icon = ({ size, color, className, align, text, ...props }) => {
   return (
     <Element
       {...props}
-      className={classnames('icon', className, {
+      className={classnames(className, {
+        icon: !text,
         [`is-${size}`]: size,
         [`is-${align}`]: align,
         [`has-text-${color}`]: color,


### PR DESCRIPTION
Currently if `Icon` `text` prop is enabled, both `icon` and `icon-text` classes are added, causing layout issue. From Bulma's documentation, only the `icon-text` class is required. This PR addresses this issue.

Closes #335, cc @Tstassin