### PR TITLE
Add standard img tag attribute support.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,12 @@
     }
   },
   "rules": {
-    "prettier/prettier": "error",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     "arrow-body-style": [2, "always"],
     "no-console": 0,
     "no-param-reassign": 0,

--- a/src/components/image/image.js
+++ b/src/components/image/image.js
@@ -121,6 +121,9 @@ Image.propTypes = {
     PropTypes.string,
   ]),
   fallback: PropTypes.string,
+  /**
+   * Applies additional classes to the `img` tag (standard `className` applies to root element)
+   */
   imageClassName: PropTypes.string,
   renderAs: PropTypes.oneOfType([
     PropTypes.func,

--- a/src/components/image/image.js
+++ b/src/components/image/image.js
@@ -5,13 +5,28 @@ import classnames from 'classnames';
 import Element from '../element';
 
 const Image = ({
+  // figure tag props
   className,
+  fullwidth,
+  // img tag props
   alt,
+  crossOrigin,
+  height,
+  ismap,
+  loading,
+  longdesc,
+  referrerpolicy,
+  sizes,
+  src,
+  srcSet,
+  useMap,
+  width,
+  // component props
   size,
   fallback,
   rounded,
-  src,
-  fullwidth,
+  imageClassName,
+  // leftovers
   ...props
 }) => {
   const [state, setState] = useState({ src });
@@ -32,7 +47,7 @@ const Image = ({
       })}
     >
       <img
-        className={classnames({
+        className={classnames(imageClassName, {
           'is-rounded': rounded,
         })}
         onError={() => {
@@ -40,14 +55,41 @@ const Image = ({
         }}
         src={state.src}
         alt={alt}
+        crossOrigin={crossOrigin}
+        height={height ? `${height}px` : null}
+        ismap={ismap}
+        loading={loading}
+        longdesc={longdesc}
+        referrerpolicy={referrerpolicy}
+        sizes={sizes}
+        srcSet={srcSet}
+        useMap={useMap}
+        width={width ? `${width}px` : null}
       />
     </Element>
   );
 };
 
 Image.propTypes = {
-  src: PropTypes.string.isRequired,
+  fullwidth: PropTypes.bool,
   alt: PropTypes.string,
+  crossOrigin: PropTypes.oneOf(['anonymous', 'use-credentials']),
+  height: PropTypes.number,
+  ismap: PropTypes.bool,
+  loading: PropTypes.oneOf(['eager', 'lazy']),
+  longdesc: PropTypes.string,
+  referrerpolicy: PropTypes.oneOf([
+    'no-referrer',
+    'no-referrer-when-downgrade',
+    'origin',
+    'origin-when-cross-origin',
+    'unsafe-url',
+  ]),
+  sizes: PropTypes.string,
+  src: PropTypes.string.isRequired,
+  srcSet: PropTypes.string,
+  useMap: PropTypes.string,
+  width: PropTypes.number,
   rounded: PropTypes.bool,
   size: PropTypes.oneOfType([
     PropTypes.oneOf([
@@ -79,7 +121,7 @@ Image.propTypes = {
     PropTypes.string,
   ]),
   fallback: PropTypes.string,
-  fullwidth: PropTypes.bool,
+  imageClassName: PropTypes.string,
   renderAs: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.string,

--- a/src/components/image/image.js
+++ b/src/components/image/image.js
@@ -56,7 +56,7 @@ const Image = ({
         src={state.src}
         alt={alt}
         crossOrigin={crossOrigin}
-        height={height ? `${height}px` : null}
+        height={height}
         ismap={ismap}
         loading={loading}
         longdesc={longdesc}
@@ -64,7 +64,7 @@ const Image = ({
         sizes={sizes}
         srcSet={srcSet}
         useMap={useMap}
-        width={width ? `${width}px` : null}
+        width={width}
       />
     </Element>
   );
@@ -74,7 +74,7 @@ Image.propTypes = {
   fullwidth: PropTypes.bool,
   alt: PropTypes.string,
   crossOrigin: PropTypes.oneOf(['anonymous', 'use-credentials']),
-  height: PropTypes.number,
+  height: PropTypes.string,
   ismap: PropTypes.bool,
   loading: PropTypes.oneOf(['eager', 'lazy']),
   longdesc: PropTypes.string,
@@ -89,7 +89,7 @@ Image.propTypes = {
   src: PropTypes.string.isRequired,
   srcSet: PropTypes.string,
   useMap: PropTypes.string,
-  width: PropTypes.number,
+  width: PropTypes.string,
   rounded: PropTypes.bool,
   size: PropTypes.oneOfType([
     PropTypes.oneOf([


### PR DESCRIPTION
While using this tool I came across the need to use the `srcset` attribute on my `img` tag but found that the attribute was being applied to the figure instead of the img tag.  This change should add support for all standard img tag attibutes so they go where they belong.

Example:
```html
<figure class="image jumbotron-img is-16by9" srcset="/images/homepage-main-768.jpg 768w, /images/homepage-main-1024.jpg 1024w, /images/homepage-main-1216.jpg 1216w, /images/homepage-main-1408.jpg 1408w, /images/homepage-main.jpg 6720w" sizes="100vw">
  <img class="" src="/images/homepage-main.jpg" alt="Homepage Main Image">
</figure>
```
Should output as:
```html
<figure class="image jumbotron-img is-16by9" >
  <img class="" src="/images/homepage-main.jpg" alt="Homepage Main Image" srcset="/images/homepage-main-768.jpg 768w, /images/homepage-main-1024.jpg 1024w, /images/homepage-main-1216.jpg 1216w, /images/homepage-main-1408.jpg 1408w, /images/homepage-main.jpg 6720w" sizes="100vw">
</figure>
```

This is my first attempt at modifying code on this project so please feel free to provide corrections or request adjustments. I'm not really familiar with TypeScript so I didn't modify that part and was unsure if I needed to.

Ohhh and the prettier mod was to remove some line ending issue I was seeing (similar to: [https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-delete-cr-prettier-prettier](https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-delete-cr-prettier-prettier)).  I use Windows for dev, I'm guessing you use Mac. Let me know if it causes issues on your end. 😄  