### PR TITLE
Fix React Typescript compilation error

### DIFF
--- a/src/components/card/index.d.ts
+++ b/src/components/card/index.d.ts
@@ -2,7 +2,7 @@ import { BulmaComponent } from '..';
 import ImageProps from '../image';
 
 declare const Card: BulmaComponent<{}, 'div'> & {
-  Image: BulmaComponent<ImageProps, 'figure'>;
+  Image: BulmaComponent<typeof ImageProps, 'figure'>;
   Content: BulmaComponent<{}, 'div'>;
   Header: BulmaComponent<{}, 'div'> & {
     Title: BulmaComponent<{}, 'div'>;


### PR DESCRIPTION
I get the following error with current setup:
```
TypeScript error in V:/../../../ClientApp/node_modules/react-bulma-components/src/components/card/index.d.ts(5,25):
'ImageProps' refers to a value, but is being used as a type here. Did you mean 'typeof ImageProps'? TS2749
```

Typescript version 4.3.5 with following tsconfig.json:
```
{
  "compilerOptions": {
    "target": "es5",
    "allowJs": true,
    "esMOduleInterop": true,
    "allowSyntheticDefaultImports": true,
    "strict": true,
    "forceConsistentCasingInFileNames": true,
    "module": "esnext",
    "moduleResolution": "node",
    "resolveJsonModule": true,
    "isolatedModules": true,
    "noEmit": true,
    "jsx": "react-jsx",
    "lib": ["es6, "dom", "es2016", "es2017"[,
    "skipLibCheck": false,
    "noFallthroughCasesInSwitch": true
  },
  "include": ["src"]
}
```

Following the recommended steps above fixed it in my application and I figured I would propose the change here in case it was something that made sense to update.