### PR TITLE
Fix Card importing ImageProps bug

### DIFF
--- a/src/components/card/index.d.ts
+++ b/src/components/card/index.d.ts
@@ -1,5 +1,5 @@
 import { BulmaComponent } from '..';
-import ImageProps from '../image';
+import { ImageProps } from '../image';
 
 declare const Card: BulmaComponent<{}, 'div'> & {
   Image: BulmaComponent<ImageProps, 'figure'>;
@@ -13,4 +13,4 @@ declare const Card: BulmaComponent<{}, 'div'> & {
   };
 };
 
-export default Card
+export default Card;

--- a/src/components/image/index.d.ts
+++ b/src/components/image/index.d.ts
@@ -1,6 +1,6 @@
 import { BulmaComponentWithoutRenderAs } from '..';
 
-interface ImageProps {
+export interface ImageProps {
   src: string;
   alt?: string;
   rounded?: boolean;


### PR DESCRIPTION
Resolves issue https://github.com/couds/react-bulma-components/issues/363 where `ImageProps` type was not being properly exported from the Image type file and imported in Card type file.