### PR TITLE
fix: change signature of Breadcrumb

### DIFF
--- a/src/components/breadcrumb/index.d.ts
+++ b/src/components/breadcrumb/index.d.ts
@@ -4,7 +4,7 @@ import { Size } from '..';
 interface BreadcrumbProps {
   separator?: 'arrow' | 'bullet' | 'dot' | 'succeeds';
   size?: Size;
-  align?: 'right' | 'center';
+  align?: 'right' | 'centered';
 }
 
 interface BreadcrumbItemProps {


### PR DESCRIPTION
Regarding to
1)  Official Bulma documentation
2) this piece of code https://github.com/arkadybag/react-bulma-components/blob/master/src/components/breadcrumb/breadcrumb.js#L21

```
const Breadcrumb = ({
  className,
  separator,
  size,
  align,
  children,
  ...props
}) => {
  return (
    <Element
      {...props}
      className={classnames('breadcrumb', className, {
        [`has-${separator}-separator`]: separator,
        [`is-${size}`]: size,
        [`is-${align}`]: align,
      })}
    >
      <ul>{children}</ul>
    </Element>
  );
};
```

We need to change it as follow
