### PR TITLE
🐞 fix: update type for gap property on columns to take a number

### DIFF
--- a/src/components/columns/columns.js
+++ b/src/components/columns/columns.js
@@ -111,6 +111,14 @@ Columns.propTypes = {
     ]),
   }),
   /**
+   * Default gap props
+   */
+  gap: PropTypes.oneOfType([
+    PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8]),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  /**
    * Defines at what breakpoint upwards the column layout should be activated. Any viewport smaller
    * than the specified breakpoint will cause `<Columns.Column>` to stack on top of each other.
    */

--- a/src/components/columns/index.d.ts
+++ b/src/components/columns/index.d.ts
@@ -1,8 +1,8 @@
-import { BulmaComponent } from '..';
-import { Breakpoint, ResponsiveModifiers } from '..';
+import { BulmaComponent, Breakpoint, ResponsiveModifiers } from '..';
 
+type GapSize = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | String | Number;
 interface GapProps {
-  gap?: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | String | Number;
+  gap?: GapSize;
 }
 
 interface ColumnGroupProps {
@@ -12,7 +12,7 @@ interface ColumnGroupProps {
   desktop?: GapProps & ResponsiveModifiers;
   widescreen?: GapProps & ResponsiveModifiers;
   breakpoint?: Breakpoint;
-  gap?: GapProps;
+  gap?: GapSize;
   multiline?: boolean;
   centered?: boolean;
   vCentered?: boolean;


### PR DESCRIPTION
The type did not match what the component was expecting. Adds `GapSize` type and uses it in `GapProps.gap` + `Columns.gap`.