### PR TITLE
Remove misleading title on previous button in Pagination

### DIFF
--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -75,7 +75,6 @@ const Pagination = ({
                   }
             }
             className="pagination-previous"
-            title="This is the first page"
             disabled={prevDisabled}
           >
             {previous}


### PR DESCRIPTION
I think the title here is misleading, as the previous button is not always the first page. 

Also, the text is not customizable as the Nest/Previous button.