### PR TITLE
fix: domRef in ElementProps was missing React.ElementRef

### DIFF
--- a/src/components/index.d.ts
+++ b/src/components/index.d.ts
@@ -173,7 +173,7 @@ export type ElementProps<
   TComponent extends RenderAsComponent
 > = ModifierProps & {
   className?: string;
-  domRef?: React.RefObject<TComponent>;
+  domRef?: React.RefObject<React.ElementRef<TComponent>>;
   renderAs?: TComponent;
   style?: React.CSSProperties;
   display?: DisplayModifier;


### PR DESCRIPTION
The domRef definition that was there would have a nonsensical type like `React.RefObject<"input">` when it should be referring to the actual element like `React.RefObject<HTMLInputElement>` based on `TComponent`. This would necessitate doing ugly casts like

```
ref as unknown as HTMLInputElement
```